### PR TITLE
rpc-url changed

### DIFF
--- a/mint/js/index.js
+++ b/mint/js/index.js
@@ -60,7 +60,7 @@ const connect = async () => {
 							symbol: "MATIC",
 							decimals: 18,
 						},
-						rpcUrls: ["https://polygon-rpc.com"],
+						rpcUrls: ["https://polygon-rpc.com/"],
 						blockExplorerUrls: ["https://polygonscan.com/"],
 					},
 				],


### PR DESCRIPTION
前までは起きなかったのですが、最後の”/”があるかないかで、違うネットワークとして認識してしまうようなので、勉強会でのネットワークの追加の仕方に合わせて、mintページにおける自動ネットワーク追加処理のrpc-urlを変更。